### PR TITLE
Fix a case when the xcodeproject does not have a TargetAttributes section

### DIFF
--- a/lib/capabilities_helper.rb
+++ b/lib/capabilities_helper.rb
@@ -50,6 +50,14 @@ class CapabilitiesHelper
   end
 
   def target_attributes
+    unless @project.root_object.attributes["TargetAttributes"]
+      @project.root_object.attributes["TargetAttributes"] = {}
+    end
+
+    unless @project.root_object.attributes["TargetAttributes"][@target.uuid]
+      @project.root_object.attributes["TargetAttributes"][@target.uuid] = {}
+    end
+
     @project.root_object.attributes["TargetAttributes"][@target.uuid]
   end
 


### PR DESCRIPTION
We did a case where TargetAttributes wasn't set, and ambient would crash.
